### PR TITLE
Example: Deploy Action Server to Fly.io

### DIFF
--- a/deploy-fly-io/LICENSE
+++ b/deploy-fly-io/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2023 Robocorp Technologies, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/deploy-fly-io/README.md
+++ b/deploy-fly-io/README.md
@@ -1,4 +1,4 @@
-# Deploy ⚡️ Action Server to fly.io
+# Deploy ⚡️Action Server to fly.io
 
 This an example on how to deploy your [Robocorp Action Server](https://github.com/robocorp/robo/tree/master/action_server/docs#readme) to [fly.io](fly.io).
 
@@ -10,10 +10,11 @@ Follow the [fly.io Speedrun](https://fly.io/docs/speedrun/) on how to setup your
 
 ## Prepare your Action Server
 
-The deployment will utilize [fly.io Docker deployment](https://fly.io/docs/languages-and-frameworks/dockerfile/) and will setup [Nginx](https://www.nginx.com) as a proxy and utilize [Supervisor](https://supervisord.org/) for process control. A configuration file is requried for each - you can leave each as is or update to your needs:
--  Docker [./docker/Dockerfile](./docker/Dockerfile) to setup the base Python image
--  Nginx [./docker/nginx.conf](./docker/nginx.conf) to setup a proxy and expose only those Action Server endpoints that are required for AI applications.
--  Supervisor [./docker/supervisord.conf](./docker/supervisord.conf) to handle launching both Action Server and Nginx in tandem and report the logs to fly.io:
+The deployment will use [fly.io Docker deployment](https://fly.io/docs/languages-and-frameworks/dockerfile/) and will setup [Nginx](https://www.nginx.com) as a proxy server and utilize [Supervisor](https://supervisord.org/) for process control. A configuration file is requried for each - you can leave each as is or update to your needs:
+
+- Docker [./docker/Dockerfile](./docker/Dockerfile) to setup the base Python image
+- Nginx [./docker/nginx.conf](./docker/nginx.conf) to setup a proxy and expose only those Action Server endpoints that are required for AI applications.
+- Supervisor [./docker/supervisord.conf](./docker/supervisord.conf) to handle launching both Action Server and Nginx in tandem and report the logs to fly.io.
 
 ---
 
@@ -41,7 +42,7 @@ fly secrets set ACTION_SERVER_KEY=your-secret-key
 ```
 
 > [!NOTE]
-> Remember and do not share the API key as you will need it when setting up your AI application
+> Protect and remember the API key – you will need it when setting up your AI application
 
 ## Deploy
 

--- a/deploy-fly-io/README.md
+++ b/deploy-fly-io/README.md
@@ -10,15 +10,17 @@ Follow the [fly.io Speedrun](https://fly.io/docs/speedrun/) on how to setup your
 
 ## Prepare your Action Server
 
-The deployment will use [fly.io Docker deployment](https://fly.io/docs/languages-and-frameworks/dockerfile/) and will setup [Nginx](https://www.nginx.com) as a proxy server and utilize [Supervisor](https://supervisord.org/) for process control. A configuration file is requried for each - you can leave each as is or update to your needs:
+The deployment will use [fly.io Docker deployment](https://fly.io/docs/languages-and-frameworks/dockerfile/) and will setup [Nginx](https://www.nginx.com) as a proxy server and utilize [Supervisor](https://supervisord.org/) for process control.
+
+Setting up configuration file for each is needed - you can leave them as in this example or update to your needs:
 
 - Docker [./docker/Dockerfile](./docker/Dockerfile) to setup the base Python image
-- Nginx [./docker/nginx.conf](./docker/nginx.conf) to setup a proxy and expose only those Action Server endpoints that are required for AI applications.
-- Supervisor [./docker/supervisord.conf](./docker/supervisord.conf) to handle launching both Action Server and Nginx in tandem and report the logs to fly.io.
+- Nginx [./docker/nginx.conf](./docker/nginx.conf) to expose endpoints need for AI application
+- Supervisor [./docker/supervisord.conf](./docker/supervisord.conf) to handle launching the applications
 
 ---
 
-As the final configuration, create the fly.io configuration file [./fly.toml](./fly.toml).
+As the final step – create the fly.io configuration file [./fly.toml](./fly.toml).
 
 Adjust the `app` value to match your application name:
 
@@ -48,12 +50,12 @@ fly secrets set ACTION_SERVER_KEY=your-secret-key
 
 Once everything is setup, run `fly launch` and follow the instructions 🚀
 
-If everything goes well 🤞 you will end up with a url like https://action-server-fly-io-example.fly.dev that is ready to be used in OpenAI GPTs and other AI applications.
+If everything goes well 🤞 you will end up with an url like https://action-server-fly-io-example.fly.dev that is ready to be used in OpenAI GPTs and other AI applications.
 
 ---
 
 ### Next steps
 
-- 📖 Follow the [fly.io documentation](https://fly.io/docs/) for next steps and further configuration of the deployment
-- 🌟 Check out other [Action Server examples](https://github.com/robocorp/actions-cookbook) for references and inspiration
-- 🙋‍♂️ Look for further help in the main[Robocorp repo](https://github.com/robocorp/robocorp)
+- 📖 Follow the [fly.io documentation](https://fly.io/docs/) for further configuration of the deployment infrastructure
+- 🌟 Check out other [Action Server examples](https://github.com/robocorp/actions-cookbook) for reference and inspiration
+- 🙋‍♂️ Look for further assistance and help in the main [Robocorp repo](https://github.com/robocorp/robocorp)

--- a/deploy-fly-io/README.md
+++ b/deploy-fly-io/README.md
@@ -10,84 +10,14 @@ Follow the [fly.io Speedrun](https://fly.io/docs/speedrun/) on how to setup your
 
 ## Prepare your Action Server
 
-THe deployment will utilize a [./docker/Dockerfile](./docker/Dockerfile) that will setup a Python based image to install and run Action Server itself, use [Nginx](https://www.nginx.com) as a proxy and [Supervisor](https://supervisord.org/) for process control. You can leave the file as is or update it to your likings and needs:
+The deployment will utilize [fly.io Docker deployment](https://fly.io/docs/languages-and-frameworks/dockerfile/) and will setup [Nginx](https://www.nginx.com) as a proxy and utilize [Supervisor](https://supervisord.org/) for process control. A configuration file is requried for each - you can leave each as is or update to your needs:
+-  Docker [./docker/Dockerfile](./docker/Dockerfile) to setup the base Python image
+-  Nginx [./docker/nginx.conf](./docker/nginx.conf) to setup a proxy and expose only those Action Server endpoints that are required for AI applications.
+-  Supervisor [./docker/supervisord.conf](./docker/supervisord.conf) to handle launching both Action Server and Nginx in tandem and report the logs to fly.io:
 
-```Dockerfile
-ARG PYTHON_VERSION=3.11
-
-FROM python:${PYTHON_VERSION}
-
-RUN apt-get update && apt-get install -y
-
-RUN mkdir -p /action-server
-WORKDIR /action-server
-
-# Install and setup Action Server
-RUN pip install robocorp-action-server
-COPY . .
-
-# Install and setup Nginx and Supervisor
-RUN apt-get update && apt-get install -y nginx supervisor && \
-    rm -rf /var/lib/apt/lists/*
-
-COPY docker/nginx.conf /etc/nginx/nginx.conf
-COPY docker/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
-
-EXPOSE 8080
-
-CMD ["/usr/bin/supervisord"]
-```
-
-Nginx will use the [./docker/nginx.conf](./docker/nginx.conf) config file to setup a proxy and expose only those Action Server endpoints that are required for AI applications.
-
-```nginx
-events {}
-
-http {
-    include       mime.types;
-    charset       utf-8;
-
-    server {
-        listen 0.0.0.0:8080;
-
-        location = / {
-            proxy_pass http://localhost:8087/openapi.json;
-        }
-
-        location /openapi.json {
-            proxy_pass http://localhost:8087/openapi.json;
-        }
-
-        location /api/ {
-            proxy_pass http://localhost:8087;
-        }
-    }
-}
-```
-
-Supervisor [./docker/supervisord.conf](./docker/supervisord.conf) will handle launching both Action Server and Nginx in tandem and report the logs to fly.io:
-
-```ini
-[supervisord]
-nodaemon=true
-
-[program:nginx]
-command=/usr/sbin/nginx -g "daemon off;"
-stdout_logfile=/dev/stdout
-stdout_logfile_maxbytes=0
-stderr_logfile=/dev/stderr
-stderr_logfile_maxbytes=0
-
-[program:action-server]
-command=action-server start --server-name=%(ENV_FLY_APP_NAME)sfly.dev --api-key=%(ENV_ACTION_SERVER_KEY)s --port 8087
-stdout_logfile=/dev/stdout
-stdout_logfile_maxbytes=0
-stderr_logfile=/dev/stderr
-stderr_logfile_maxbytes=0
-```
 ---
 
-As the final configuration, a fly.io configuration file [./fly.toml](./fly.toml) is needed.
+As the final configuration, create the fly.io configuration file [./fly.toml](./fly.toml).
 
 Adjust the `app` value to match your application name:
 

--- a/deploy-fly-io/README.md
+++ b/deploy-fly-io/README.md
@@ -1,16 +1,16 @@
-# Deploy ⚡️ Action Server to Fly.io
+# Deploy ⚡️ Action Server to fly.io
 
-This an example on how to deploy your [Robocorp Action Server](https://github.com/robocorp/robo/tree/master/action_server/docs#readme) to [Fly.io](Fly.io).
+This an example on how to deploy your [Robocorp Action Server](https://github.com/robocorp/robo/tree/master/action_server/docs#readme) to [fly.io](fly.io).
 
-This example assumes you have your action already created, tested and ready to launch. The example also uses minimal configuration as a starting point for your own custom setup.
+This example assumes you have your actions already created, tested and ready to launch. The example also uses minimal configuration as a starting point for your own custom setup.
 
-## Setup Fly.io
+## Setup fly.io
 
-Follow the [Fly.io Speedrun](https://fly.io/docs/speedrun/) on how to setup your account. You will need to [install the flyctl](https://fly.io/docs/hands-on/install-flyctl/) command-line utility and setup an account with it.
+Follow the [fly.io Speedrun](https://fly.io/docs/speedrun/) on how to setup your account. You will need to [install the flyctl](https://fly.io/docs/hands-on/install-flyctl/) command-line utility and setup an account via it.
 
-## Prepare Action Server
+## Prepare your Action Server
 
-For this setup, create a [./docker/Dockerfile](./docker/Dockerfile) that will setup a Python based image to install and run Action Server itself, use [Nginx](https://www.nginx.com) as a proxy and [Supervisor](https://supervisord.org/) for process control. You can leave the file as is or update it to your likings and needs:
+THe deployment will utilize a [./docker/Dockerfile](./docker/Dockerfile) that will setup a Python based image to install and run Action Server itself, use [Nginx](https://www.nginx.com) as a proxy and [Supervisor](https://supervisord.org/) for process control. You can leave the file as is or update it to your likings and needs:
 
 ```Dockerfile
 ARG PYTHON_VERSION=3.11
@@ -22,9 +22,11 @@ RUN apt-get update && apt-get install -y
 RUN mkdir -p /action-server
 WORKDIR /action-server
 
+# Install and setup Action Server
 RUN pip install robocorp-action-server
 COPY . .
 
+# Install and setup Nginx and Supervisor
 RUN apt-get update && apt-get install -y nginx supervisor && \
     rm -rf /var/lib/apt/lists/*
 
@@ -36,7 +38,7 @@ EXPOSE 8080
 CMD ["/usr/bin/supervisord"]
 ```
 
-Nginx will use the [./docker/nginx.conf](./docker/nginx.conf) file to setup a proxy and expose only those Action Server endpoints that are required for most AI applications.
+Nginx will use the [./docker/nginx.conf](./docker/nginx.conf) config file to setup a proxy and expose only those Action Server endpoints that are required for AI applications.
 
 ```nginx
 events {}
@@ -63,7 +65,7 @@ http {
 }
 ```
 
-Supervisor [./docker/supervisord.conf](./docker/supervisord.conf) will handle launching both Action Server and Nginx in tandem and report the logs to Fly.io:
+Supervisor [./docker/supervisord.conf](./docker/supervisord.conf) will handle launching both Action Server and Nginx in tandem and report the logs to fly.io:
 
 ```ini
 [supervisord]
@@ -83,8 +85,11 @@ stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
 ```
+---
 
-And as a final configuration, a Fly.io configuration file [./fly.toml](./fly.toml) is needed. Adjust the `app` value to match your application name:
+As the final configuration, a fly.io configuration file [./fly.toml](./fly.toml) is needed.
+
+Adjust the `app` value to match your application name:
 
 ```toml
 app = "action-server-fly-io-example"
@@ -99,7 +104,7 @@ app = "action-server-fly-io-example"
 
 ## Set your API key
 
-To protect your actions, setup an API key for Action Server – [the Fly.io secrets](https://fly.io/docs/reference/secrets/) feature is perfect for this:
+To protect your actions, setup an API key for Action Server – [the fly.io secrets](https://fly.io/docs/reference/secrets/) feature is perfect for this:
 
 ```sh
 fly secrets set ACTION_SERVER_KEY=your-secret-key
@@ -114,8 +119,10 @@ Once everything is setup, run `fly launch` and follow the instructions 🚀
 
 If everything goes well 🤞 you will end up with a url like https://action-server-fly-io-example.fly.dev that is ready to be used in OpenAI GPTs and other AI applications.
 
+---
+
 ### Next steps
 
-- 📖 Follow the [Fly.io documentation](https://fly.io/docs/) for next steps and further configuration of the deployment
+- 📖 Follow the [fly.io documentation](https://fly.io/docs/) for next steps and further configuration of the deployment
 - 🌟 Check out other [Action Server examples](https://github.com/robocorp/actions-cookbook) for references and inspiration
 - 🙋‍♂️ Look for further help in the main[Robocorp repo](https://github.com/robocorp/robocorp)

--- a/deploy-fly-io/README.md
+++ b/deploy-fly-io/README.md
@@ -1,0 +1,121 @@
+# Deploy ⚡️ Action Server to Fly.io
+
+This an example on how to deploy your [Robocorp Action Server](https://github.com/robocorp/robo/tree/master/action_server/docs#readme) to [Fly.io](Fly.io).
+
+This example assumes you have your action already created, tested and ready to launch. The example also uses minimal configuration as a starting point for your own custom setup.
+
+## Setup Fly.io
+
+Follow the [Fly.io Speedrun](https://fly.io/docs/speedrun/) on how to setup your account. You will need to [install the flyctl](https://fly.io/docs/hands-on/install-flyctl/) command-line utility and setup an account with it.
+
+## Prepare Action Server
+
+For this setup, create a [./docker/Dockerfile](./docker/Dockerfile) that will setup a Python based image to install and run Action Server itself, use [Nginx](https://www.nginx.com) as a proxy and [Supervisor](https://supervisord.org/) for process control. You can leave the file as is or update it to your likings and needs:
+
+```Dockerfile
+ARG PYTHON_VERSION=3.11
+
+FROM python:${PYTHON_VERSION}
+
+RUN apt-get update && apt-get install -y
+
+RUN mkdir -p /action-server
+WORKDIR /action-server
+
+RUN pip install robocorp-action-server
+COPY . .
+
+RUN apt-get update && apt-get install -y nginx supervisor && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY docker/nginx.conf /etc/nginx/nginx.conf
+COPY docker/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
+
+EXPOSE 8080
+
+CMD ["/usr/bin/supervisord"]
+```
+
+Nginx will use the [./docker/nginx.conf](./docker/nginx.conf) file to setup a proxy and expose only those Action Server endpoints that are required for most AI applications.
+
+```nginx
+events {}
+
+http {
+    include       mime.types;
+    charset       utf-8;
+
+    server {
+        listen 0.0.0.0:8080;
+
+        location = / {
+            proxy_pass http://localhost:8087/openapi.json;
+        }
+
+        location /openapi.json {
+            proxy_pass http://localhost:8087/openapi.json;
+        }
+
+        location /api/ {
+            proxy_pass http://localhost:8087;
+        }
+    }
+}
+```
+
+Supervisor [./docker/supervisord.conf](./docker/supervisord.conf) will handle launching both Action Server and Nginx in tandem and report the logs to Fly.io:
+
+```ini
+[supervisord]
+nodaemon=true
+
+[program:nginx]
+command=/usr/sbin/nginx -g "daemon off;"
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+
+[program:action-server]
+command=action-server start --server-name=%(ENV_FLY_APP_NAME)sfly.dev --api-key=%(ENV_ACTION_SERVER_KEY)s --port 8087
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+```
+
+And as a final configuration, a Fly.io configuration file [./fly.toml](./fly.toml) is needed. Adjust the `app` value to match your application name:
+
+```toml
+app = "action-server-fly-io-example"
+
+[build]
+  dockerfile = "docker/Dockerfile"
+
+[http_service]
+  internal_port = 8080
+  force_https = true
+```
+
+## Set your API key
+
+To protect your actions, setup an API key for Action Server – [the Fly.io secrets](https://fly.io/docs/reference/secrets/) feature is perfect for this:
+
+```sh
+fly secrets set ACTION_SERVER_KEY=your-secret-key
+```
+
+> [!NOTE]
+> Remember and do not share the API key as you will need it when setting up your AI application
+
+## Deploy
+
+Once everything is setup, run `fly launch` and follow the instructions 🚀
+
+If everything goes well 🤞 you will end up with a url like https://action-server-fly-io-example.fly.dev that is ready to be used in OpenAI GPTs and other AI applications.
+
+### Next steps
+
+- 📖 Follow the [Fly.io documentation](https://fly.io/docs/) for next steps and further configuration of the deployment
+- 🌟 Check out other [Action Server examples](https://github.com/robocorp/actions-cookbook) for references and inspiration
+- 🙋‍♂️ Look for further help in the main[Robocorp repo](https://github.com/robocorp/robocorp)

--- a/deploy-fly-io/action.py
+++ b/deploy-fly-io/action.py
@@ -43,8 +43,5 @@ def compare_time_zones(user_timezone: str, compare_to_timezones: str) -> str:
             output.append(f"- Current time in {timezone} is {target_now.strftime('%I:%M %p')}, the difference with {user_timezone} is {time_diff} hours")
         except pytz.InvalidTimeError:
             output.append(f"- Timezone '{timezone}' could not be found. Use tz database format.")
-
-    # Pretty print for log
-    print("\n".join(output))
     
-    return os.environ["FLY_APP_NAME"] # "\n".join(output)
+    return "\n".join(output)

--- a/deploy-fly-io/action.py
+++ b/deploy-fly-io/action.py
@@ -1,0 +1,50 @@
+"""
+A simple AI Action template for comparing timezones
+
+Please checkout the base guidance on AI Actions in our main repository readme:
+https://github.com/robocorp/robocorp/blob/master/README.md
+
+"""
+import os
+from robocorp.actions import action
+from datetime import datetime
+import pytz
+
+
+@action
+def compare_time_zones(user_timezone: str, compare_to_timezones: str) -> str:
+    """
+    Compares user timezone time difference to given timezones
+
+    Args:
+        user_timezone (str): User timezone in tz database format. Example: "Europe/Helsinki"
+        compare_to_timezones (str): Comma seperated timezones in tz database format. Example: "America/New_York, Asia/Kolkata"
+
+    Returns:
+        str: List of requested timezones, their current time and the user time difference in hours
+    """
+    output: list[str] = []
+
+    try:
+        user_tz = pytz.timezone(user_timezone)
+        user_now = datetime.now(user_tz)
+    except pytz.InvalidTimeError:
+        return f"Timezone '{user_timezone}' could not be found. Use tz database format."
+    
+    output.append(f"- Current time in {user_timezone} is {user_now.strftime('%I:%M %p')}")
+
+    target_timezones = [s.strip() for s in compare_to_timezones.split(',')]
+    for timezone in target_timezones:
+        try:
+            target_tz = pytz.timezone(timezone)
+            target_now = datetime.now(target_tz)
+            time_diff = (int(user_now.strftime('%z')) - int(target_now.strftime('%z'))) / 100
+
+            output.append(f"- Current time in {timezone} is {target_now.strftime('%I:%M %p')}, the difference with {user_timezone} is {time_diff} hours")
+        except pytz.InvalidTimeError:
+            output.append(f"- Timezone '{timezone}' could not be found. Use tz database format.")
+
+    # Pretty print for log
+    print("\n".join(output))
+    
+    return os.environ["FLY_APP_NAME"] # "\n".join(output)

--- a/deploy-fly-io/conda.yaml
+++ b/deploy-fly-io/conda.yaml
@@ -1,0 +1,14 @@
+# For more details on the format and content:
+# https://github.com/robocorp/rcc/blob/master/docs/recipes.md#what-is-in-condayaml
+
+channels:
+  - conda-forge
+
+dependencies:
+  - python=3.10.12
+  - pip=23.2.1
+  - robocorp-truststore=0.8.0
+  - pip:
+      - robocorp==1.4.0
+      - robocorp-actions==0.0.4
+      - pytz==2023.3

--- a/deploy-fly-io/docker/Dockerfile
+++ b/deploy-fly-io/docker/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update && apt-get install -y
 RUN mkdir -p /action-server
 WORKDIR /action-server
 
-RUN pip install robocorp-action-server
+RUN pip install --upgrade robocorp-action-server
 COPY . .
 
 RUN apt-get update && apt-get install -y nginx supervisor && \

--- a/deploy-fly-io/docker/Dockerfile
+++ b/deploy-fly-io/docker/Dockerfile
@@ -1,0 +1,21 @@
+ARG PYTHON_VERSION=3.11
+
+FROM python:${PYTHON_VERSION}
+
+RUN apt-get update && apt-get install -y
+
+RUN mkdir -p /action-server
+WORKDIR /action-server
+
+RUN pip install robocorp-action-server
+COPY . .
+
+RUN apt-get update && apt-get install -y nginx supervisor && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY docker/nginx.conf /etc/nginx/nginx.conf
+COPY docker/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
+
+EXPOSE 8080
+
+CMD ["/usr/bin/supervisord"]

--- a/deploy-fly-io/docker/nginx.conf
+++ b/deploy-fly-io/docker/nginx.conf
@@ -1,0 +1,22 @@
+events {}
+
+http {
+    include       mime.types;
+    charset       utf-8;
+
+    server {
+        listen 0.0.0.0:8080;
+
+        location = / {
+            proxy_pass http://localhost:8087/openapi.json;
+        }
+
+        location /openapi.json {
+            proxy_pass http://localhost:8087/openapi.json;
+        }
+
+        location /api/ {
+            proxy_pass http://localhost:8087;
+        }
+    }
+}

--- a/deploy-fly-io/docker/supervisord.conf
+++ b/deploy-fly-io/docker/supervisord.conf
@@ -9,7 +9,7 @@ stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
 
 [program:action-server]
-command=action-server start --server-name=%(ENV_FLY_APP_NAME)sfly.dev --api-key=%(ENV_ACTION_SERVER_KEY)s --port 8087
+command=action-server start --server-url=https://%(ENV_FLY_APP_NAME)s.fly.dev --api-key=%(ENV_ACTION_SERVER_KEY)s --port 8087
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr

--- a/deploy-fly-io/docker/supervisord.conf
+++ b/deploy-fly-io/docker/supervisord.conf
@@ -1,0 +1,16 @@
+[supervisord]
+nodaemon=true
+
+[program:nginx]
+command=/usr/sbin/nginx -g "daemon off;"
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+
+[program:action-server]
+command=action-server start --server-name=%(ENV_FLY_APP_NAME)sfly.dev --api-key=%(ENV_ACTION_SERVER_KEY)s --port 8087
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0

--- a/deploy-fly-io/fly.toml
+++ b/deploy-fly-io/fly.toml
@@ -1,5 +1,3 @@
-# fly.toml app configuration file generated for action-server-fly-io-example on 2024-01-16T17:17:25+02:00
-#
 # See https://fly.io/docs/reference/configuration/ for information about how to use this file.
 #
 
@@ -12,8 +10,3 @@ primary_region = "waw"
 [http_service]
   internal_port = 8080
   force_https = true
-
-[[vm]]
-  cpu_kind = "shared"
-  cpus = 1
-  memory_mb = 1024

--- a/deploy-fly-io/fly.toml
+++ b/deploy-fly-io/fly.toml
@@ -1,0 +1,19 @@
+# fly.toml app configuration file generated for action-server-fly-io-example on 2024-01-16T17:17:25+02:00
+#
+# See https://fly.io/docs/reference/configuration/ for information about how to use this file.
+#
+
+app = "action-server-fly-io-example"
+primary_region = "waw"
+
+[build]
+  dockerfile = "docker/Dockerfile"
+
+[http_service]
+  internal_port = 8080
+  force_https = true
+
+[[vm]]
+  cpu_kind = "shared"
+  cpus = 1
+  memory_mb = 1024

--- a/deploy-fly-io/robot.yaml
+++ b/deploy-fly-io/robot.yaml
@@ -1,0 +1,27 @@
+# For more details on the format and content:
+# https://github.com/robocorp/rcc/blob/master/docs/recipes.md#what-is-in-robotyaml
+
+tasks:
+  Run and Debug Action:
+    shell: python -m robocorp.actions run --json-input devdata/input.json
+
+  Start Action Server:
+    shell: action-server start
+  
+  Expose Action Server:
+    shell: action-server start --expose
+
+environmentConfigs:
+  - environment_windows_amd64_freeze.yaml
+  - environment_linux_amd64_freeze.yaml
+  - environment_darwin_amd64_freeze.yaml
+  - conda.yaml
+
+artifactsDir: output
+
+PATH:
+  - .
+PYTHONPATH:
+  - .
+ignoreFiles:
+  - .gitignore


### PR DESCRIPTION
This an example on how to deploy your [Robocorp Action Server](https://github.com/robocorp/robo/tree/master/action_server/docs#readme) to [Fly.io](Fly.io).