### PR TITLE
add example-request

### DIFF
--- a/example-request/README.md
+++ b/example-request/README.md
@@ -1,0 +1,18 @@
+# Request example
+
+Starting with robocorp-actions 0.1.0, it's possible to collect data from the received request by creating a request: Request argument.
+
+The data currently available in the request is:
+
+headers: contains all the headers received.
+cookies: contains all the cookies received in headers in a dict-like API.
+
+Check out [robocorp-actions guide](https://github.com/robocorp/robocorp/blob/master/actions/docs/guides/00-request.md) for more information.
+
+To run this use `action-server start`.
+
+You may then check http://localhost:8080 for the Action Server UI.
+There you can try the action `print_request` out.
+
+You can expose this action to internet with `action-server start --expose`.
+Then you may use it in services such as OpenAI GPT Action.

--- a/example-request/actions.py
+++ b/example-request/actions.py
@@ -1,0 +1,20 @@
+from typing import Optional
+from robocorp.actions import action, Request
+
+
+@action
+def print_request(request: Request) -> str:
+    """
+    Prints passed in headers and cookies from the request
+    """
+
+    headers: Optional[str] = request.headers
+    cookies: Optional[str] = request.cookies
+
+    for key in headers:
+        print(f"🐤 {key}: {headers[key]}")
+
+    for key in cookies:
+        print(f"🍪 {key}: {cookies[key]}")
+
+    return "Hello"

--- a/example-request/package.yaml
+++ b/example-request/package.yaml
@@ -1,0 +1,19 @@
+# Required: A short name for the action package
+name: Request example
+
+# Required: A description of what's in the action package.
+description: This shows the very basic example of accessing request data
+
+# Required: The current version of this action package.
+version: 0.0.1
+
+# Required: A link to where the documentation on the package lives.
+documentation: https://github.com/robocorp/actions-cookbook/blob/master/example-request/README.md
+
+dependencies:
+  conda-forge:
+    - python=3.10.12
+    - pip=23.2.1
+  pypi:
+    - robocorp=2.0.0
+    - robocorp-actions=0.1.0


### PR DESCRIPTION
Starting with robocorp-actions 0.1.0, it's possible to collect data from the received request by creating a request: Request argument.

Example of using it.