### PR TITLE
feat: add "example-secret" example

### DIFF
--- a/example-secret/README.md
+++ b/example-secret/README.md
@@ -1,0 +1,13 @@
+# Secret example
+
+Starting with robocorp-actions 0.2.0, it is possible to define and read secrets in actions.
+
+Check out the [robocorp-actions guide](https://github.com/robocorp/robocorp/blob/master/action_server/docs/guides/07-secrets.md) for more information.
+
+To run this use `action-server start`.
+
+You may then check http://localhost:8080 for the Action Server UI.
+There you can try the action `print_request` out.
+
+You can expose this action to internet with `action-server start --expose`.
+Then you may use it in services such as OpenAI GPT Action.

--- a/example-secret/README.md
+++ b/example-secret/README.md
@@ -7,7 +7,7 @@ Check out the [robocorp-actions guide](https://github.com/robocorp/robocorp/blob
 To run this use `action-server start`.
 
 You may then check http://localhost:8080 for the Action Server UI.
-There you can try the action `print_request` out.
+There you can try the action `greet_with_secret` out.
 
 You can expose this action to internet with `action-server start --expose`.
 Then you may use it in services such as OpenAI GPT Action.

--- a/example-secret/actions.py
+++ b/example-secret/actions.py
@@ -1,0 +1,15 @@
+from robocorp.actions import action, Secret
+
+
+@action
+def greet_with_secret(name: str, secret: Secret) -> str:
+    """
+    Greets user with a secret message
+
+    Args:
+        name (str): Name of the user
+
+    Returns:
+        str: Returns a greeting with a secret message
+    """
+    return f"Hello {name}, the secret message is {secret.value}"

--- a/example-secret/actions.py
+++ b/example-secret/actions.py
@@ -2,7 +2,7 @@ from robocorp.actions import action, Secret
 
 
 @action
-def greet_with_secret(name: str, secret: Secret) -> str:
+def greet_with_secret(name: str, secret_message: Secret) -> str:
     """
     Greets user with a secret message
 
@@ -12,4 +12,4 @@ def greet_with_secret(name: str, secret: Secret) -> str:
     Returns:
         str: Returns a greeting with a secret message
     """
-    return f"Hello {name}, the secret message is {secret.value}"
+    return f"Hello {name}, the secret message is {secret_message.value}"

--- a/example-secret/devdata/input_greet_with_secret.json
+++ b/example-secret/devdata/input_greet_with_secret.json
@@ -1,0 +1,4 @@
+{
+    "name": "You",
+    "secret": "Super secret"
+}

--- a/example-secret/devdata/input_greet_with_secret.json
+++ b/example-secret/devdata/input_greet_with_secret.json
@@ -1,4 +1,4 @@
 {
     "name": "You",
-    "secret": "Super secret"
+    "secret_message": "1+1=3"
 }

--- a/example-secret/package.yaml
+++ b/example-secret/package.yaml
@@ -1,0 +1,16 @@
+name: Secret Greeter
+
+description: Action package description
+
+version: 0.0.1
+
+documentation: https://github.com/robocorp/robocorp/blob/master/action_server/docs/guides/07-secrets.md
+
+dependencies:
+  conda-forge:
+    - python=3.10.12
+    - pip=23.2.1
+    - robocorp-truststore=0.8.0
+  pypi:
+    - robocorp=2.0.0
+    - robocorp-actions=0.2.0

--- a/example-secret/package.yaml
+++ b/example-secret/package.yaml
@@ -1,6 +1,6 @@
 name: Secret Greeter
 
-description: Action package description
+description: Greets user with a secret message
 
 version: 0.0.1
 


### PR DESCRIPTION
## Background

Adding the "secret" example that @rihardsgravis built to showcase the use of `Secret` in actions

## Changes
- Add the action code
- Add a very simple Readme
- Include DevData

## Notes

- I went with a specific name for the secret (`secret_message`) so that developers understand that any name goes as long as it's a `Secret`
- I also included the `devdata` to be able to run it locally right away