### PR TITLE
chore: update api-jokes, greeter and example-secret

### DIFF
--- a/api-jokes/actions.py
+++ b/api-jokes/actions.py
@@ -1,7 +1,8 @@
 import requests
-from robocorp.actions import action
+from sema4ai.actions import action
 
 API_URL = "https://icanhazdadjoke.com/"
+
 
 @action
 def get_a_random_joke() -> str:

--- a/api-jokes/package.yaml
+++ b/api-jokes/package.yaml
@@ -1,22 +1,14 @@
-
-# Required: A short name for the action package
 name: Get random joke
-    
-# Required: A description of what's in the action package.
+
 description: This simple example shows how to make API calls with Actions.
 
-# Required: The current version of this action package.
-version: 0.0.1
-
-# Required: A link to where the documentation on the package lives.
 documentation: https://github.com/robocorp/actions-cookbook/tree/master/api-jokes/README.md
 
 dependencies:
   conda-forge:
-  - python=3.10.12
-  - pip=23.2.1
-  - robocorp-truststore=0.8.0
+    - python=3.10.12
+    - uv=0.1.37
   pypi:
-  - robocorp-actions=0.0.7
+  - sema4ai-actions=0.5.0
   - requests=2.31.0
 

--- a/example-secret/actions.py
+++ b/example-secret/actions.py
@@ -8,6 +8,7 @@ def greet_with_secret(name: str, secret_message: Secret) -> str:
 
     Args:
         name (str): Name of the user
+        secret_message: The secret message to disclose.
 
     Returns:
         str: Returns a greeting with a secret message

--- a/example-secret/package.yaml
+++ b/example-secret/package.yaml
@@ -9,4 +9,4 @@ dependencies:
     - python=3.10.12
     - uv=0.1.37
   pypi:
-    - sema4ai-actions=0.3.1
+    - sema4ai-actions=0.5.0

--- a/greeter/actions.py
+++ b/greeter/actions.py
@@ -1,4 +1,4 @@
-from robocorp.actions import action
+from sema4ai.actions import action
 
 
 @action

--- a/greeter/package.yaml
+++ b/greeter/package.yaml
@@ -1,22 +1,12 @@
-
-# Required: A short name for the action package
 name: Greeter example
 
-# Required: A description of what's in the action package.
 description: This shows the very basic python action in action
 
-# Required: The current version of this action package.
-version: 0.0.1
-
-# Required: A link to where the documentation on the package lives.
 documentation: https://github.com/robocorp/actions-cookbook/blob/master/greeter/README.md
 
 dependencies:
   conda-forge:
-  - python=3.10.12
-  - pip=23.2.1
-  - robocorp-truststore=0.8.0
+    - python=3.10.12
+    - uv=0.1.37
   pypi:
-  - robocorp=2.0.0
-  - robocorp-actions=0.1.0
-  - requests=2.31.0
+    - sema4ai-actions=0.5.0


### PR DESCRIPTION
## Background

Updating the `greeter`, `api-jokes` and `example-secret` examples to use the latest version of sema4ai-actions.

## Changes

- Update dependencies
- Remove unnecessary or outdated comments
- Add the secret description for the `example-secret` (required when using `sema4ai-actions=0.5.0`)